### PR TITLE
fix(estimates): Button loses submit message on invalid submit

### DIFF
--- a/app/views/estimates/create.js.erb
+++ b/app/views/estimates/create.js.erb
@@ -6,6 +6,7 @@
     addEstimate.remove()
     closeModal()
   <% else %>
+    <% provide(:button_text, 'Create') %>
     updateModal("New estimate", "<%= j(render partial: 'modal_body') %>")
   <% end %>
 })()

--- a/app/views/estimates/update.js.erb
+++ b/app/views/estimates/update.js.erb
@@ -2,5 +2,6 @@
   <%= render partial: 'update_estimates', locals: {estimate: @estimate} %>
   closeModal()
 <% else %>
+  <% provide(:button_text, 'Save Changes') %>
   updateModal("Edit estimate", "<%= j(render partial: 'modal_body') %>")
 <% end %>

--- a/spec/features/estimates_manage_spec.rb
+++ b/spec/features/estimates_manage_spec.rb
@@ -74,14 +74,24 @@ RSpec.describe "managing estimates", js: true do
     let!(:estimate) { create(:estimate, story: story, user: user) }
 
     before do
+      create(:story, project: project)
       visit project_path(id: project.id)
-      click_link "Edit Estimate"
     end
 
-    it "shows me an error message" do
+    it "shows me an error message when I edit an invalid estimate" do
+      click_link "Edit Estimate"
       set_estimates(21, 1)
       click_button "Save Changes"
       expect(page).to have_content "Validation error Worst case estimate should be greater than best case estimate."
+      expect(page).to have_button("Save Changes", id: "edit")
+    end
+
+    it "shows me an error message when I create an invalid estimate" do
+      click_link "Add Estimate"
+      set_estimates(21, 1)
+      click_button "Create"
+      expect(page).to have_content "Validation error Worst case estimate should be greater than best case estimate."
+      expect(page).to have_button("Create", id: "edit")
     end
   end
 


### PR DESCRIPTION
Fix task [5: Bug: button loses its label when estimate form is invalid](https://trello.com/c/DSYDYpj2/5-bug-button-loses-its-label-when-estimate-form-is-invalid)
